### PR TITLE
Fix for the Packagist URL on the download page of http://zetacomponents.org/

### DIFF
--- a/download.html
+++ b/download.html
@@ -73,7 +73,7 @@
     
         <h2>Downloads</h2><p>There are no releases of zeta Components available yet. We will try to release a new bundle as soon as possible.</p><p>You can always check out Zeta Components from Github at the following URL: <a href="http://github.com/zetacomponents">http://github.com/zetacomponents</a></p>
 
-        <p>You can also install all components using <a hreF="http://packagist.org/zetacomponents">Packagist</a>.</p>
+        <p>You can also install all components using <a hreF="http://packagist.org/packages/zetacomponents">Packagist</a>.</p>
 
 	</div>
 

--- a/download/index.html
+++ b/download/index.html
@@ -73,7 +73,7 @@
     
         <h2>Downloads</h2><p>There are no releases of zeta Components available yet. We will try to release a new bundle as soon as possible.</p><p>You can always check out Zeta Components from Github at the following URL: <a href="http://github.com/zetacomponents">http://github.com/zetacomponents</a></p>
 
-        <p>You can also install all components using <a hreF="http://packagist.org/zetacomponents">Packagist</a>.</p>
+        <p>You can also install all components using <a hreF="http://packagist.org/packages/zetacomponents">Packagist</a>.</p>
 
 	</div>
 


### PR DESCRIPTION
http://zetacomponents.org/download.html and http://zetacomponents.org/download/index.html point to http://packagist.org/zetacomponents but that link doesn't work. It should be http://packagist.org/packages/zetacomponents/
