### PR TITLE
Temporary fix for broken links in zetacomponents.org site, mainly in documentation part.

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html 
+<html
 	xmlns="http://www.w3.org/1999/xhtml"
 	xml:lang="en"
 	lang="en">
@@ -27,6 +27,19 @@
 	<link rel="Stylesheet" type="text/css" href="/styles/screen.css" media="screen" />
 	<link rel="Stylesheet" type="text/css" href="/styles/print.css" media="print" />
 
+    <script type="text/javascript">
+    <!--
+    // Temporary Quick-and-dirty fix for broken links
+    (function() {
+
+        var url = location.href;
+        if (url.indexOf("/zetacomponents/") == 0) {
+            location.replace(url.replace(/^\/zetacomponents\//, '/'));
+        }
+    })();
+
+    -->
+    </script>
 
 	<title>Zeta Components - high quality PHP components</title>
 </head>
@@ -58,7 +71,7 @@
 </ul>
 
 	<div class="content">
-    
+
 		<h2>Site note found</h2><p>The site you tried to access does not exist (any more). We are sorry for this. Please try to relocate the requested site using the site navigation.</p><!--Local Variables:
 mode: rst
 fill-column: 79
@@ -68,7 +81,7 @@ vim: et syn=rst tw=79-->
 	</div>
 
 	<div class="footer">
-	
+
 </div>
 </div>
 </body>


### PR DESCRIPTION
All documentation tutorials links pointing to api are broken.

Warning : this is a Quick-and-dirty fix:

A javascript code has been added to 404.html file that checks if the asked url starts with /zetacomponents/ if so it redirects the user to the proper target url by removing /zetacomponents/ from it.

I have two propals for definitive solution :
    - create a zetacomponent folder and move documentation into it
    - replace all occurences of /zetacomponent/ in all files

Thanks and happy new year
